### PR TITLE
Smoothly switch to multiroot workspace

### DIFF
--- a/.code-workspace
+++ b/.code-workspace
@@ -1,0 +1,20 @@
+{
+	"folders": [
+		{
+			"name": "openshift-test",
+			"path": "/projects/openshift-test"
+		}
+	],
+    "settings": {
+		"editor.cursorBlinking": "expand",
+		"editor.cursorStyle": "block",
+        "workbench.colorTheme": "Kimbie Dark",
+        "workbench.iconTheme": "dot"
+    },
+	"extensions": {
+		"recommendations": [
+			"redhat.vscode-yaml",
+			"anweber.dot-icons"
+		]
+	}
+}

--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -4,4 +4,7 @@ metadata:
 components:
   - name: python
     container:
-      image: registry.redhat.io/devspaces/udi-rhel9
+      image: registry.redhat.io/devspaces/udi-rhel8
+      env:
+        - name: VSCODE_DEFAULT_WORKSPACE
+          value: /projects/openshift-test/.code-workspace


### PR DESCRIPTION
A workaround to switch to multiroot workspace

The idea here is to keep the workspace file here in the repository and to configure VS Code to use this file by defining of VSCODE_DEFAULT_WORKSPACE environment variable.

Potentially solves https://github.com/Nykredit/openshift_test/issues/1

To test the changes, create a repository withwith
https://github.com/vitaliy-guliy/openshift_test/tree/add-workspace-file
 

### !!!
Please do not pay attention to the fact the underline character was replaced by dash.
It's a bug appeared when cloning a project, I've noticed it while playing with this sample.
